### PR TITLE
chore: not to require coc-tsserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deno extension for coc.nvim, forked from
 
 ## Install
 
-`:CocInstall coc-tsserver coc-deno`
+`:CocInstall coc-deno`
 
 ## Commands
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -59,11 +59,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const extension = extensions.all.find((e) =>
     e.id === TS_LANGUAGE_FEATURES_EXTENSION
   );
-  if (!extension) {
-    return window.showMessage(`${TS_LANGUAGE_FEATURES_EXTENSION} is needed`);
+  if (extension) {
+    await extension.activate();
+    synchronizeConfiguration(extension.exports);
   }
-  await extension.activate();
-  synchronizeConfiguration(extension.exports);
 
   const run: Executable = {
     command: "deno",
@@ -118,7 +117,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
           // information on the event not being reliable.
           { settings: null },
         );
-        synchronizeConfiguration(extension.exports);
+        if (extension) {
+          synchronizeConfiguration(extension.exports);
+        }
       }
     }),
     // Register a content provider for Deno resolved read-only files.


### PR DESCRIPTION
The extension `coc-tsserver` is not needed to be installed. The plugin `typescript-deno-plugin` is just disabling some features of 
`coc-tsserver`.
Jumping to definition, hover, linting, completions are working only with `coc-deno`.